### PR TITLE
updating href for license page to license.html

### DIFF
--- a/includes/_append.fragment-footer.html
+++ b/includes/_append.fragment-footer.html
@@ -1,4 +1,4 @@
                  | <a style="color: #81BEF7" target="_blank" href="{{site.data.fhir.canonical}}/history.html">Version History <img alt="external" style="vertical-align: baseline" src="external.png"/></a></a> |
-                 <a style="color: #81BEF7" target="_blank" href="tho-license-v1_0.html"> <img alt="external" style="vertical-align: baseline" src="cc0.png"/></a> |
+                 <a style="color: #81BEF7" target="_blank" href="license.html"> <img alt="external" style="vertical-align: baseline" src="cc0.png"/></a> |
                  <!--<a style="color: #81BEF7" href="todo.html">Search</a> | --> 
                  <a style="color: #81BEF7" target="_blank" href="https://jira.hl7.org/projects/UP">Propose a change <img alt="external" style="vertical-align: baseline" src="external.png"/></a>


### PR DESCRIPTION
Per HQ the license page is changing from 'tho-license-v1_0' to just 'license'.  Changing the template to reflect that.